### PR TITLE
Bonk done() in async tests

### DIFF
--- a/src/components/desktopKeywordAnalysis/DesktopKeywordAnalysis.test.ts
+++ b/src/components/desktopKeywordAnalysis/DesktopKeywordAnalysis.test.ts
@@ -29,27 +29,26 @@ describe("service.desktopKeywordAnalysis", () => {
   });
 
   describe("competitors organic", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopKeywordAnalysisCompetitorsParams = {
         ...defaultOptions,
       };
-      const competitors = await service.desktopKeywordAnalysis.competitorsOrganic(
-        testDomain,
-        options
-      );
+      const competitors =
+        await service.desktopKeywordAnalysis.competitorsOrganic(
+          testDomain,
+          options
+        );
       expectWebsiteMeta(competitors.meta, testDomain, options);
 
       competitors.data.forEach((datum) => {
         expect(datum.score).toBeGreaterThanOrEqual(0);
         expect(datum.url).toBeTruthy();
       });
-
-      done();
     });
   });
 
   describe("competitors paid", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopKeywordAnalysisCompetitorsParams = {
         ...defaultOptions,
       };
@@ -63,13 +62,11 @@ describe("service.desktopKeywordAnalysis", () => {
         expect(datum.score).toBeGreaterThanOrEqual(0);
         expect(datum.url).toBeTruthy();
       });
-
-      done();
     });
   });
 
   describe("analyze organic", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopKeywordAnalysisAnalyzeParams = {
         ...defaultOptions,
         limit: 3,
@@ -87,13 +84,11 @@ describe("service.desktopKeywordAnalysis", () => {
         expect(datum.destination_url).toBeTruthy();
         expect(datum.website_categories).toBeTruthy();
       });
-
-      done();
     });
   });
 
   describe("analyze paid", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopKeywordAnalysisAnalyzeParams = {
         ...defaultOptions,
         limit: 3,
@@ -111,8 +106,6 @@ describe("service.desktopKeywordAnalysis", () => {
         expect(datum.destination_url).toBeTruthy();
         expect(datum.website_categories).toBeTruthy();
       });
-
-      done();
     });
   });
 });

--- a/src/components/desktopOther/DesktopOther.test.ts
+++ b/src/components/desktopOther/DesktopOther.test.ts
@@ -36,7 +36,7 @@ describe("service.desktopOther", () => {
   });
 
   describe("similar sites", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const similarSites = await service.desktopOther.similarSites(testDomain);
       expectWebsiteMeta(similarSites.meta, testDomain);
 
@@ -44,13 +44,11 @@ describe("service.desktopOther", () => {
       const similarSite = similarSites.similar_sites.shift();
       expect(similarSite.score).toBeGreaterThan(0);
       expect(similarSite.url).toBeTruthy();
-
-      done();
     });
   });
 
   describe("audience interest", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options = {
         ...defaultOptions,
         ...optionDates,
@@ -67,13 +65,11 @@ describe("service.desktopOther", () => {
       expect(record.overlap).toBeGreaterThan(0);
       expect(record.domain).toBeTruthy();
       expect(typeof record.has_adsense === "boolean").toBeTruthy();
-
-      done();
     });
   });
 
   describe("audience interest", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options = {
         ...defaultOptions,
         ...optionDates,
@@ -90,25 +86,21 @@ describe("service.desktopOther", () => {
       expect(record.overlap).toBeGreaterThan(0);
       expect(record.domain).toBeTruthy();
       expect(typeof record.has_adsense === "boolean").toBeTruthy();
-
-      done();
     });
   });
 
   describe("category rank", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const categoryRank = await service.desktopOther.categoryRank(testDomain);
       expectWebsiteMeta(categoryRank.meta, testDomain);
 
       expect(categoryRank.rank).toBeGreaterThan(0);
       expect(categoryRank.category).toBeTruthy();
-
-      done();
     });
   });
 
   describe("top sites desktop", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopOtherTopSitesParams = {
         ...defaultOptions,
       };
@@ -122,13 +114,11 @@ describe("service.desktopOther", () => {
       const desktopSite = topSites.top_sites.shift();
       expect(desktopSite.domain).toBeTruthy();
       expect(desktopSite.rank).toBeGreaterThan(0);
-
-      done();
     });
   });
 
   describe("top sites mobile", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopOtherTopSitesParams = {
         ...defaultOptions,
       };
@@ -142,13 +132,11 @@ describe("service.desktopOther", () => {
       const desktopSite = topSites.top_sites.shift();
       expect(desktopSite.domain).toBeTruthy();
       expect(desktopSite.rank).toBeGreaterThan(0);
-
-      done();
     });
   });
 
   describe("api lite", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const data = await service.desktopOther.apiLite(testDomain);
 
       expect(data.site_name).toBeTruthy();
@@ -271,8 +259,6 @@ describe("service.desktopOther", () => {
       });
       expect(data.daily_visits_min_date).toBeTruthy();
       expect(data.daily_visits_max_date).toBeTruthy();
-
-      done();
     });
   });
 });

--- a/src/components/desktopWebTrafficSources/DesktopWebTrafficSources.test.ts
+++ b/src/components/desktopWebTrafficSources/DesktopWebTrafficSources.test.ts
@@ -58,7 +58,7 @@ describe("service.desktopWebTrafficSources", () => {
   });
 
   describe("overview", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const results = await service.desktopWebTrafficSources.overview(
         testDomain,
         defaultOptions
@@ -72,13 +72,11 @@ describe("service.desktopWebTrafficSources", () => {
         expect(source.source_type).toBeTruthy();
         expect(source.share).toBeGreaterThan(0);
       });
-
-      done();
     });
   });
 
   describe("overview share", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopWebTrafficSourcesOverviewShareParams = {
         ...defaultOptions,
         granularity: "Monthly",
@@ -102,13 +100,11 @@ describe("service.desktopWebTrafficSources", () => {
             });
           });
         });
-
-      done();
     });
   });
 
   describe("pages per visit", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopWebTrafficSourcesEngagementMetricsParams = {
         ...defaultOptions,
         granularity: "Monthly",
@@ -120,31 +116,28 @@ describe("service.desktopWebTrafficSources", () => {
 
       expectWebsiteMeta(results.meta, testDomain, options);
       expectEngagementMetric(results);
-
-      done();
     });
   });
 
   describe("average visit duration", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopWebTrafficSourcesEngagementMetricsParams = {
         ...defaultOptions,
         granularity: "Monthly",
       };
-      const results = await service.desktopWebTrafficSources.averageVisitDuration(
-        testDomain,
-        options
-      );
+      const results =
+        await service.desktopWebTrafficSources.averageVisitDuration(
+          testDomain,
+          options
+        );
 
       expectWebsiteMeta(results.meta, testDomain, options);
       expectEngagementMetric(results);
-
-      done();
     });
   });
 
   describe("bounce rate", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopWebTrafficSourcesEngagementMetricsParams = {
         ...defaultOptions,
         granularity: "Monthly",
@@ -156,13 +149,11 @@ describe("service.desktopWebTrafficSources", () => {
 
       expectWebsiteMeta(results.meta, testDomain, options);
       expectEngagementMetric(results);
-
-      done();
     });
   });
 
   describe("social referrals", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const referrals = await service.desktopWebTrafficSources.socialReferrals(
         testDomain,
         defaultOptions
@@ -175,13 +166,11 @@ describe("service.desktopWebTrafficSources", () => {
         expect(referral.share).toBeGreaterThan(0);
         expectChange(referral);
       });
-
-      done();
     });
   });
 
   describe("referrals", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const referrals = await service.desktopWebTrafficSources.referrals(
         testDomain,
         defaultOptions
@@ -195,13 +184,11 @@ describe("service.desktopWebTrafficSources", () => {
         expect(referral.domain).toBeTruthy();
         expectChange(referral);
       });
-
-      done();
     });
   });
 
   describe("ad networks", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const adNetworks = await service.desktopWebTrafficSources.adNetworks(
         testDomain,
         defaultOptions
@@ -214,13 +201,11 @@ describe("service.desktopWebTrafficSources", () => {
         expect(adNetwork.share).toBeGreaterThan(0);
         expectChange(adNetwork);
       });
-
-      done();
     });
   });
 
   describe("publishers", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const publishers = await service.desktopWebTrafficSources.publishers(
         testDomain,
         defaultOptions
@@ -234,8 +219,6 @@ describe("service.desktopWebTrafficSources", () => {
         expect(adNetwork.share).toBeGreaterThan(0);
         expectChange(adNetwork);
       });
-
-      done();
     });
   });
 
@@ -262,67 +245,61 @@ describe("service.desktopWebTrafficSources", () => {
       });
     };
 
-    it("should get organic", async (done) => {
-      const keywords = await service.desktopWebTrafficSources.organicSearchKeywords(
-        testDomain,
-        options
-      );
+    it("should get organic", async () => {
+      const keywords =
+        await service.desktopWebTrafficSources.organicSearchKeywords(
+          testDomain,
+          options
+        );
       expectKeywords(keywords);
-
-      done();
     });
 
-    it("should get paid", async (done) => {
-      const keywords = await service.desktopWebTrafficSources.paidSearchKeywords(
-        testDomain,
-        options
-      );
+    it("should get paid", async () => {
+      const keywords =
+        await service.desktopWebTrafficSources.paidSearchKeywords(
+          testDomain,
+          options
+        );
       expectKeywords(keywords);
-
-      done();
     });
 
-    it("should get branded", async (done) => {
+    it("should get branded", async () => {
       const keywords = await service.desktopWebTrafficSources.brandedKeywords(
         testDomain,
         options
       );
       expectKeywords(keywords);
-
-      done();
     });
 
-    it("should get non-branded", async (done) => {
-      const keywords = await service.desktopWebTrafficSources.nonBrandedKeywords(
-        testDomain,
-        options
-      );
+    it("should get non-branded", async () => {
+      const keywords =
+        await service.desktopWebTrafficSources.nonBrandedKeywords(
+          testDomain,
+          options
+        );
       expectKeywords(keywords);
-
-      done();
     });
 
-    it("should get questions", async (done) => {
+    it("should get questions", async () => {
       const keywords = await service.desktopWebTrafficSources.questionsKeywords(
         testDomain,
         options
       );
       expectKeywords(keywords);
-
-      done();
     });
   });
 
   describe("search visits distribution", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IDesktopWebTrafficSourcesSearchVisitDistributionParams = {
         ...defaultOptions,
         ...optionDates,
       };
-      const distribution = await service.desktopWebTrafficSources.searchVisitsDistribution(
-        testDomain,
-        options
-      );
+      const distribution =
+        await service.desktopWebTrafficSources.searchVisitsDistribution(
+          testDomain,
+          options
+        );
 
       expectWebsiteMeta(distribution.meta, testDomain, options);
       distribution.data.forEach((distribution) => {
@@ -341,17 +318,16 @@ describe("service.desktopWebTrafficSources", () => {
           distribution.visits_distribution.paid_non_branded_visits
         ).toBeGreaterThanOrEqual(0);
       });
-
-      done();
     });
   });
 
   describe("organic outgoing links", () => {
-    it("should get", async (done) => {
-      const referrals = await service.desktopWebTrafficSources.organicOutgoingLinks(
-        testDomain,
-        defaultOptions
-      );
+    it("should get", async () => {
+      const referrals =
+        await service.desktopWebTrafficSources.organicOutgoingLinks(
+          testDomain,
+          defaultOptions
+        );
 
       expectWebsiteMeta(referrals.meta, testDomain, defaultOptions);
       expect(referrals.visits).toBeGreaterThanOrEqual(0);
@@ -361,17 +337,16 @@ describe("service.desktopWebTrafficSources", () => {
         expect(referral.domain).toBeTruthy();
         expectChange(referral);
       });
-
-      done();
     });
   });
 
   describe("outgoing ad networks", () => {
-    it("should get", async (done) => {
-      const networks = await service.desktopWebTrafficSources.outgoingAdNetworks(
-        testDomain,
-        defaultOptions
-      );
+    it("should get", async () => {
+      const networks =
+        await service.desktopWebTrafficSources.outgoingAdNetworks(
+          testDomain,
+          defaultOptions
+        );
 
       expectWebsiteMeta(networks.meta, testDomain, defaultOptions);
       expectRankings(networks);
@@ -380,17 +355,16 @@ describe("service.desktopWebTrafficSources", () => {
         expect(network.domain).toBeTruthy();
         expectChange(network);
       });
-
-      done();
     });
   });
 
   describe("outgoing ad advertisers", () => {
-    it("should get", async (done) => {
-      const advertisers = await service.desktopWebTrafficSources.outgoingAdAdvertisers(
-        testDomain,
-        defaultOptions
-      );
+    it("should get", async () => {
+      const advertisers =
+        await service.desktopWebTrafficSources.outgoingAdAdvertisers(
+          testDomain,
+          defaultOptions
+        );
 
       expectWebsiteMeta(advertisers.meta, testDomain, defaultOptions);
       expect(advertisers.visits).toBeGreaterThanOrEqual(0);
@@ -399,8 +373,6 @@ describe("service.desktopWebTrafficSources", () => {
         expect(advertiser.domain).toBeTruthy();
         expectChange(advertiser);
       });
-
-      done();
     });
   });
 });

--- a/src/components/mobileWebTrafficSources/MobileWebTrafficSources.test.ts
+++ b/src/components/mobileWebTrafficSources/MobileWebTrafficSources.test.ts
@@ -40,7 +40,7 @@ describe("service.desktopWebTrafficSources", () => {
   });
 
   describe("overview share", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: IMobileWebTrafficSourcesOverviewShareParams = {
         ...defaultOptions,
         ...optionDates,
@@ -64,13 +64,11 @@ describe("service.desktopWebTrafficSources", () => {
             });
           });
         });
-
-      done();
     });
   });
 
   describe("referrals", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const referrals = await service.mobileWebTrafficSources.referrals(
         testDomain,
         {
@@ -87,8 +85,6 @@ describe("service.desktopWebTrafficSources", () => {
         expect(referral.domain).toBeTruthy();
         expectChange(referral);
       });
-
-      done();
     });
   });
 });

--- a/src/components/salesSolution/SalesSolution.test.ts
+++ b/src/components/salesSolution/SalesSolution.test.ts
@@ -23,7 +23,7 @@ describe("service.salesSolution", () => {
   });
 
   describe("lead enrichment", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const options: ILeadEnrichmentParams = {
         country: "us",
         start_date: Service.formatDate(earlierThanThat, "month"),
@@ -104,14 +104,12 @@ describe("service.salesSolution", () => {
         expect(geographyShare.country).toBeGreaterThan(0);
         expect(geographyShare.share).toBeGreaterThanOrEqual(0);
       }
-
-      done();
     });
   });
 
   describe("technographics", () => {
     // At the time of writing, this was returning 403 Forbidden for my login
-    it.skip("should get", async (done) => {
+    it.skip("should get", async () => {
       const technographics = await service.salesSolution.technographics(
         testDomain
       );
@@ -128,8 +126,6 @@ describe("service.salesSolution", () => {
       expect(technology.free_paid).toBeTruthy();
       // expect(technology.sub_category).toBeTruthy();
       expect(technology.technology_name).toBeTruthy();
-
-      done();
     });
   });
 });

--- a/src/components/totalTraffic/TotalTraffic.test.ts
+++ b/src/components/totalTraffic/TotalTraffic.test.ts
@@ -36,7 +36,7 @@ describe("service.totalTraffic", () => {
   });
 
   describe("error handling", () => {
-    it("should throw an error if a bad domain is provided", async (done) => {
+    it("should throw an error if a bad domain is provided", async () => {
       expect.assertions(3);
       service.totalTraffic
         .visits(testDomain.replace(".", ""), options)
@@ -44,13 +44,12 @@ describe("service.totalTraffic", () => {
           expect(error.isSimilarWebError).toBeTruthy();
           expect(error.message).toMatch("Error");
           expect(error.code).toBeTruthy();
-          done();
         });
     });
   });
 
   describe("visits", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const results = await service.totalTraffic.visits(testDomain, options);
       expect(results).toBeTruthy();
       expectWebsiteMeta(results.meta, testDomain, options);
@@ -59,13 +58,11 @@ describe("service.totalTraffic", () => {
       const item = results.visits.shift();
       expect(item.date).toBeTruthy();
       expect(item.visits).toBeGreaterThan(0);
-
-      done();
     });
   });
 
   describe("pages / visits", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const results = await service.totalTraffic.pagesVisits(
         testDomain,
         options
@@ -77,13 +74,11 @@ describe("service.totalTraffic", () => {
       const item = results.pages_per_visit.shift();
       expect(item.date).toBeTruthy();
       expect(item.pages_per_visit).toBeGreaterThan(0);
-
-      done();
     });
   });
 
   describe("average visit duration", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const results = await service.totalTraffic.averageVisitDuration(
         testDomain,
         options
@@ -95,13 +90,11 @@ describe("service.totalTraffic", () => {
       const item = results.average_visit_duration.shift();
       expect(item.date).toBeTruthy();
       expect(item.average_visit_duration).toBeGreaterThan(0);
-
-      done();
     });
   });
 
   describe("bounce rate", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const results = await service.totalTraffic.bounceRate(
         testDomain,
         options
@@ -113,13 +106,11 @@ describe("service.totalTraffic", () => {
       const item = results.bounce_rate.shift();
       expect(item.date).toBeTruthy();
       expect(item.bounce_rate).toBeGreaterThan(0);
-
-      done();
     });
   });
 
   describe("desktop mobile split", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const optionsWithDates: ITotalTrafficDesktopMobileSplitParams = {
         ...defaultOptions,
         start_date: Service.formatDate(earlierThanThat, "month"),
@@ -133,12 +124,11 @@ describe("service.totalTraffic", () => {
       expectWebsiteMeta(results.meta, testDomain, optionsWithDates);
       expect(results.desktop_visit_share).toBeGreaterThanOrEqual(0);
       expect(results.mobile_web_visit_share).toBeGreaterThanOrEqual(0);
-      done();
     });
   });
 
   describe("deduplicated audience", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const optionsWithDates: ITotalTrafficDeduplicatedAudienceParams = {
         ...defaultOptions,
         start_date: Service.formatDate(earlierThanThat, "month"),
@@ -165,8 +155,6 @@ describe("service.totalTraffic", () => {
       expect(
         data.dedup_data.total_deduplicated_audience
       ).toBeGreaterThanOrEqual(0);
-
-      done();
     });
   });
 });

--- a/src/components/utilities/Utilities.test.ts
+++ b/src/components/utilities/Utilities.test.ts
@@ -13,7 +13,7 @@ describe("service.utilities", () => {
   });
 
   describe("capabilities", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const capabilities = await service.utilities.capabilities();
       expect(capabilities).toBeTruthy();
       expect(capabilities.remaining_hits).toBeGreaterThanOrEqual(0);
@@ -34,12 +34,11 @@ describe("service.utilities", () => {
       expectCapabilitiesData(capabilities.app_engagement_data);
       expectCapabilitiesData(capabilities.web_desktop_data);
       expectCapabilitiesData(capabilities.web_mobile_data);
-      done();
     });
   });
 
   describe("categories", () => {
-    it("should get", async (done) => {
+    it("should get", async () => {
       const categories = await service.utilities.categories();
       expect(categories).toBeTruthy();
       expect(categories.Arts_and_Entertainment).toBeTruthy();
@@ -66,8 +65,6 @@ describe("service.utilities", () => {
       expect(categories.Travel_and_Tourism).toBeTruthy();
       expect(categories.Vehicles).toBeTruthy();
       expect(categories.Adult).toBeTruthy();
-
-      done();
     });
   });
 


### PR DESCRIPTION
Removed the `done`s which caused many tests to fail. 

There _are_ still test failures on my end, even with a valid `API_KEY`, but I'm not gonna worry about those right now. ¯\_(ツ)_/¯